### PR TITLE
Make Success and Failure instances hashable

### DIFF
--- a/tryingsnake/__init__.py
+++ b/tryingsnake/__init__.py
@@ -248,7 +248,10 @@ class Success(Try_[T]):
                 self._v == other._v)
 
     def __hash__(self):
-        return hash(self._v)
+        try:
+            return hash(self._v)
+        except TypeError as e:
+            raise TypeError("Cannot hash try with unhashable value") from e
 
     def get(self) -> T:
         return self._v
@@ -312,7 +315,10 @@ class Failure(Try_[T]):
             self._v.args == other._v.args)
 
     def __hash__(self):
-        return hash(self._v)
+        try:
+            return hash(self._v)
+        except TypeError as e:
+            raise TypeError("Cannot hash try with unhashable value") from e
 
     def get(self):
         raise self._v

--- a/tryingsnake/__init__.py
+++ b/tryingsnake/__init__.py
@@ -247,6 +247,9 @@ class Success(Try_[T]):
         return (isinstance(other, Success) and
                 self._v == other._v)
 
+    def __hash__(self):
+        return hash(self._v)
+
     def get(self) -> T:
         return self._v
 
@@ -307,6 +310,9 @@ class Failure(Try_[T]):
             # are not good here
             type(self._v) is type(other._v) and
             self._v.args == other._v.args)
+
+    def __hash__(self):
+        return hash(self._v)
 
     def get(self):
         raise self._v

--- a/tryingsnake/test/test_try.py
+++ b/tryingsnake/test/test_try.py
@@ -1,5 +1,6 @@
 from operator import add, truediv
 import unittest
+import pytest
 from tryingsnake import Try_, Try, Success, Failure
 
 
@@ -153,6 +154,10 @@ class TryTestCase(unittest.TestCase):
         self.assertTrue(hash(Success(1)) == 1)
         e = Exception("e")
         self.assertTrue(hash(Failure(e)) == hash(Failure(e)))
+
+    def test_fail_with_unhashable_value(self):
+        with pytest.raises(TypeError):
+            hash(Success([1]))
 
 
 if __name__ == '__main__':

--- a/tryingsnake/test/test_try.py
+++ b/tryingsnake/test/test_try.py
@@ -148,5 +148,12 @@ class TryTestCase(unittest.TestCase):
         self.assertFalse(Failure(Exception("e")))
         self.assertTrue(Success(1))
 
+    def test_hashable(self):
+        self.assertTrue(hash(Success(1)) == hash(Success(1)))
+        self.assertTrue(hash(Success(1)) == 1)
+        e = Exception("e")
+        self.assertTrue(hash(Failure(e)) == hash(Failure(e)))
+
+
 if __name__ == '__main__':
     unittest.main()  # pragma: no cover


### PR DESCRIPTION
In Scala Success and Failure can be keys to a Map:
```scala 
Map(Success(1) -> 2)
res28: scala.collection.immutable.Map[scala.util.Success[Int],Int] = Map(Success(1) -> 2)
```
However  this is not possible in Python as these classes are not hashable:
```
 hash(Success(1))

TypeError: unhashable type: 'Success'
```

This PR adds the `__hash__` method to both Success and Failure classes. I tried adding it to the parent class but for some reason it did not work. 
