### PR TITLE
Add basic curried implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,25 @@ Examples
     ['TypeError', 'ValueError', 'TypeError']
     ```
 
+-   Inline exception handling:
+
+    ```python
+    >>> from tryingsnake.curried import Try
+    >>> map(Try(str.split), ["foo bar", None])  # doctest:+ELLIPSIS
+    <map at ...>
+    ```
+
+-   Decorate your functions
+
+    ```python
+    >>> from tryingsnake.curried import Try as try_
+    >>> @try_
+    ... def scale_imag(x):
+    ...     return complex(x.real, x.imag * 2)
+    >>> [scale_imag(x) for x in [1 + 2j, "3", 42 + 0j]]
+    [Success((1+4j)), Failure(AttributeError("'str' object has no attribute 'real'")), Success((42+0j))]
+    ```
+
 Installation
 ============
 

--- a/tryingsnake/curried.py
+++ b/tryingsnake/curried.py
@@ -1,0 +1,20 @@
+import tryingsnake
+
+
+def Try(f):
+    """A curried version of Try.
+
+    :param f: Callable[..., T]
+    :return: Callable[..., Try_[T]]
+
+    >>> from operator import add, truediv
+    >>> try_div = Try(truediv)
+    >>> try_div(1, 0)  # doctest:+ELLIPSIS
+    Failure(ZeroDivisionError(...))
+    >>> try_add = Try(add)
+    >>> try_add(1, 2)
+    Success(3)
+    """
+    def _(*args, **kwargs):
+        return tryingsnake.Try(f, *args, **kwargs)
+    return _

--- a/tryingsnake/curried.pyi
+++ b/tryingsnake/curried.pyi
@@ -1,0 +1,6 @@
+import tryingsnake
+from typing import Callable, TypeVar
+
+T = TypeVar('T')
+
+def Try(f: Callable[..., T]) -> Callable[..., tryingsnake.Try_[T]]: ...

--- a/tryingsnake/test/test_curried_try.py
+++ b/tryingsnake/test/test_curried_try.py
@@ -1,0 +1,30 @@
+from operator import add, truediv
+import unittest
+import pytest
+from tryingsnake.curried import Try as CurriedTry
+
+
+class CurriedTryTestCase(unittest.TestCase):
+    def test_can_take_args_and_fail(self):
+        try_trudiv = CurriedTry(truediv)
+        self.assertTrue(try_trudiv(1, 0).isFailure)
+
+    def test_can_take_args_and_succeed(self):
+        try_add = CurriedTry(add)
+        self.assertTrue(try_add(1, 3).isSuccess)
+
+    def test_can_take_kwargs_and_fail(self):
+        def f(a, b):
+            return a / b
+        try_f = CurriedTry(f)
+        self.assertTrue(try_f(a=1, b=0).isFailure)               
+
+    def test_can_take_kwargs_and_succeed(self):
+        def f(a, b):
+            return a + b
+        try_f = CurriedTry(f)
+        self.assertTrue(try_f(a=1, b=3).isSuccess)
+
+
+if __name__ == '__main__':
+    unittest.main()  # pragma: no cover


### PR DESCRIPTION
Example usage:

```python
from tryingsnake.curried import Try

try_split = Try(str.split)

map(try_split, ["foo bar", None])
```

It can be also used as a decorator (though maybe we should have `try_` variant for that)

```python
from tryingsnake.curried import Try

@Try
def try_div(x, y):
    return x / y

try_div(1, 0)
## Failure(ZeroDivisionError('division by zero')
```